### PR TITLE
add missing EPEL GPG key

### DIFF
--- a/tasks/install-pkgs.yml
+++ b/tasks/install-pkgs.yml
@@ -9,6 +9,10 @@
     - ansible_os_family == "RedHat"
     - freeipa_server_enable_epel_repo
 
+- name: Add EPEL GPG key
+  rpm_key:
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+
 - name: Install FreeIPA server dependency packages
   package:
     name: "{{ freeipa_server_dependency_pkgs }}"

--- a/tasks/install-pkgs.yml
+++ b/tasks/install-pkgs.yml
@@ -12,6 +12,9 @@
 - name: Add EPEL GPG key
   rpm_key:
     key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+  when:
+    - ansible_os_family == "RedHat"
+    - freeipa_server_enable_epel_repo
 
 - name: Install FreeIPA server dependency packages
   package:


### PR DESCRIPTION
On some systems, the EPEL GPG key might be missing and therefore the role will fail - see also issue #6.